### PR TITLE
implement data source which returns signed URLs

### DIFF
--- a/b2/data_source_b2_bucket_file_signed_url.go
+++ b/b2/data_source_b2_bucket_file_signed_url.go
@@ -1,0 +1,78 @@
+//####################################################################
+//
+// File: b2/data_source_b2_bucket_file.go
+//
+// Copyright 2021 Backblaze Inc. All Rights Reserved.
+//
+// License https://www.backblaze.com/using_b2_code.html
+//
+//####################################################################
+
+package b2
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func dataSourceB2BucketFileSignedUrl() *schema.Resource {
+	return &schema.Resource{
+		Description: "B2 signed URL for a bucket file data source.",
+
+		ReadContext: dataSourceB2BucketFileSignedUrlRead,
+
+		Schema: map[string]*schema.Schema{
+			"bucket_id": {
+				Description:  "The ID of the bucket.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"file_name": {
+				Description:  "The file name.",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"duration": {
+				Description: "The duration for which the presigned URL is valid",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
+			"signed_url": {
+				Description: "The signed URL for the given file",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceB2BucketFileSignedUrlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*Client)
+	const name = "bucket_file_signed_url"
+	const op = DATA_SOURCE_READ
+
+	input := map[string]interface{}{
+		"bucket_id": d.Get("bucket_id").(string),
+		"file_name": d.Get("file_name").(string),
+		"duration":  d.Get("duration").(int),
+	}
+
+	output, err := client.apply(name, op, input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(output["_sha1"].(string))
+
+	err = client.populate(name, op, output, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/b2/data_source_b2_bucket_file_signed_url.go
+++ b/b2/data_source_b2_bucket_file_signed_url.go
@@ -1,8 +1,8 @@
 //####################################################################
 //
-// File: b2/data_source_b2_bucket_file.go
+// File: b2/data_source_b2_bucket_file_signed_url.go
 //
-// Copyright 2021 Backblaze Inc. All Rights Reserved.
+// Copyright 2022 Backblaze Inc. All Rights Reserved.
 //
 // License https://www.backblaze.com/using_b2_code.html
 //
@@ -67,7 +67,7 @@ func dataSourceB2BucketFileSignedUrlRead(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	d.SetId(output["_sha1"].(string))
+	d.SetId(output["signed_url"].(string))
 
 	err = client.populate(name, op, output, d)
 	if err != nil {

--- a/b2/data_source_b2_bucket_file_signed_url_test.go
+++ b/b2/data_source_b2_bucket_file_signed_url_test.go
@@ -1,0 +1,66 @@
+//####################################################################
+//
+// File: b2/data_source_b2_bucket_file_test.go
+//
+// Copyright 2021 Backblaze Inc. All Rights Reserved.
+//
+// License https://www.backblaze.com/using_b2_code.html
+//
+//####################################################################
+
+package b2
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceB2BucketFileSignedUrl_singleFile(t *testing.T) {
+	parentResourceName := "b2_bucket.test"
+	resourceName := "b2_bucket_file_version.test"
+	dataSourceName := "data.b2_bucket_file_signed_url.test"
+
+	bucketName := acctest.RandomWithPrefix("test-b2-tfp")
+	tempFile := createTempFile(t, "hello")
+	defer os.Remove(tempFile)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceB2BucketFileSignedUrlConfig_singleFile(bucketName, tempFile),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "bucket_id", parentResourceName, "bucket_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "file_name", resourceName, "file_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "signed_url"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceB2BucketFileSignedUrlConfig_singleFile(bucketName string, tempFile string) string {
+	return fmt.Sprintf(`
+resource "b2_bucket" "test" {
+  bucket_name = "%s"
+  bucket_type = "allPublic"
+}
+
+resource "b2_bucket_file_version" "test" {
+  bucket_id = b2_bucket.test.id
+  file_name = "temp.txt"
+  source = "%s"
+}
+
+data "b2_bucket_file_signed_url" "test" {
+  bucket_id = b2_bucket_file_version.test.bucket_id
+  file_name = b2_bucket_file_version.test.file_name
+  duration = 3600
+}
+`, bucketName, tempFile)
+}

--- a/b2/data_source_b2_bucket_file_signed_url_test.go
+++ b/b2/data_source_b2_bucket_file_signed_url_test.go
@@ -1,8 +1,8 @@
 //####################################################################
 //
-// File: b2/data_source_b2_bucket_file_test.go
+// File: b2/data_source_b2_bucket_file_signed_url_test.go
 //
-// Copyright 2021 Backblaze Inc. All Rights Reserved.
+// Copyright 2022 Backblaze Inc. All Rights Reserved.
 //
 // License https://www.backblaze.com/using_b2_code.html
 //
@@ -38,6 +38,7 @@ func TestAccDataSourceB2BucketFileSignedUrl_singleFile(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "bucket_id", parentResourceName, "bucket_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_name", resourceName, "file_name"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "signed_url"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id", dataSourceName, "signed_url"),
 				),
 			},
 		},
@@ -48,7 +49,7 @@ func testAccDataSourceB2BucketFileSignedUrlConfig_singleFile(bucketName string, 
 	return fmt.Sprintf(`
 resource "b2_bucket" "test" {
   bucket_name = "%s"
-  bucket_type = "allPublic"
+  bucket_type = "allPrivate"
 }
 
 resource "b2_bucket_file_version" "test" {

--- a/b2/provider.go
+++ b/b2/provider.go
@@ -57,11 +57,12 @@ func New(version string, exec string) func() *schema.Provider {
 				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
-				"b2_account_info":    dataSourceB2AccountInfo(),
-				"b2_application_key": dataSourceB2ApplicationKey(),
-				"b2_bucket":          dataSourceB2Bucket(),
-				"b2_bucket_file":     dataSourceB2BucketFile(),
-				"b2_bucket_files":    dataSourceB2BucketFiles(),
+				"b2_account_info":           dataSourceB2AccountInfo(),
+				"b2_application_key":        dataSourceB2ApplicationKey(),
+				"b2_bucket":                 dataSourceB2Bucket(),
+				"b2_bucket_file":            dataSourceB2BucketFile(),
+				"b2_bucket_file_signed_url": dataSourceB2BucketFileSignedUrl(),
+				"b2_bucket_files":           dataSourceB2BucketFiles(),
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"b2_application_key":     resourceB2ApplicationKey(),

--- a/python-bindings/b2_terraform/terraform_structures.py
+++ b/python-bindings/b2_terraform/terraform_structures.py
@@ -46,6 +46,13 @@ FILE_KEYS = {
     "file_versions": FILE_VERSION_KEYS,
 }
 
+FILE_SIGNED_URL_KEYS = {
+    "bucket_id": True,
+    "file_name": True,
+    "duration": True,
+    "signed_url": True,
+}
+
 FILES_KEYS = {
     "bucket_id": True,
     "folder_name": True,


### PR DESCRIPTION
Disclaimer: This was intended to be a PR against my fork, but it seemed my GitHub workflow broke down.

In order to provision some of the machines in Terraform, I need to download a couple of files from a private B2 bucket. Instead of attempting to install the B2 CLI tool + application key, it's much easier to create the pre-signed URL for limited duration (while the provisioning is happening) and pass it instead. This allows the provisioning machine to use regular `curl` to download the required file.

I've added a small test to validate my changes seems to be working. I will be doing actual integration tests in the coming days.

I didn't see a contribution guide, so let me know if you need anything. I think the actual API - is it treated as a data source or a resource is totally up for discussion.