### PR TITLE
Add govulncheck to developer tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Infrastructure
 * Upgrade Terraform versions in CI to 1.14 and 1.13
 * Use ruff as a python-bindings formatter/linter
+* Add `govulncheck` to developer tools
 
 ## [0.12.1] - 2026-02-21
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 
 default: build
 
-.PHONY: _pybindings deps deps-check format lint testacc clean build install docs docs-lint
+.PHONY: _pybindings deps deps-check format lint vulncheck testacc clean build install docs docs-lint
 
 _pybindings:
 ifeq ($(origin NOPYBINDINGS), undefined)
@@ -22,6 +22,7 @@ deps: _pybindings
 	@cd tools && go mod download
 	@cd tools && go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 	@cd tools && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+	@cd tools && go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 	@cd tools && go mod tidy
 
 deps-check:
@@ -40,6 +41,10 @@ lint: _pybindings
 	@test -f b2/py-terraform-provider-b2 || touch b2/py-terraform-provider-b2 # required by go:embed in bindings.go
 	@go vet ./...
 	@golangci-lint run ./...
+
+vulncheck:
+	@test -f b2/py-terraform-provider-b2 || touch b2/py-terraform-provider-b2 # required by go:embed in bindings.go
+	@govulncheck ./...
 
 testacc: _pybindings
 	@cp python-bindings/dist/py-terraform-provider-b2 b2/


### PR DESCRIPTION
## Summary
- `make deps` now installs `govulncheck@v1.1.4` (last release compatible with Go 1.24) alongside the other developer tools.
- New `make vulncheck` target runs `govulncheck ./...` against the provider; touches the `go:embed` placeholder first so it works without a built python-bindings binary.