### PR TITLE
Update b2_bucket revision in state after an update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ website/vendor
 # Go
 .go-version
 
+# Scratch
+tmp/
+
 # Provider binary
 /terraform-provider-b2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `expiration_timestamp` to `b2_application_key` resource and data source
 * Add `valid_duration_in_seconds` to `b2_application_key` resource
 
+### Fixed
+* Update `revision` in state after updating a `b2_bucket` resource
+
 ### Infrastructure
 * Upgrade Terraform versions in CI to 1.14 and 1.13
 * Use ruff as a python-bindings formatter/linter

--- a/b2/resource_b2_bucket.go
+++ b/b2/resource_b2_bucket.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -30,6 +31,13 @@ func resourceB2Bucket() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		// The API bumps the revision on every change. Mark it as computed
+		// whenever any other field changes so terraform stores the new value
+		// instead of reporting it as drift on the next plan.
+		CustomizeDiff: customdiff.ComputedIf("revision", func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+			return len(d.GetChangedKeysPrefix("")) > 0
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"bucket_name": {

--- a/b2/resource_b2_bucket_test.go
+++ b/b2/resource_b2_bucket_test.go
@@ -105,6 +105,7 @@ func TestAccResourceB2Bucket_all(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.0.days_from_starting_to_canceling_unfinished_large_files", "3"),
 					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "options.0", "s3"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "3"),
 				),
 			},
 		},
@@ -218,6 +219,7 @@ func TestAccResourceB2Bucket_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "options.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "options.0", "s3"),
+					resource.TestCheckResourceAttr(resourceName, "revision", "2"),
 				),
 			},
 		},
@@ -262,6 +264,35 @@ resource "b2_bucket" "test" {
 	}
 }
 `, bucketName, fileLockEnabled)
+}
+
+func TestAccResourceB2Bucket_revisionUpdatedOnChange(t *testing.T) {
+	resourceName := "b2_bucket.test"
+	bucketName := acctest.RandomWithPrefix("test-b2-tfp")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceB2BucketConfig_basic(bucketName),
+				Check:  resource.TestCheckResourceAttr(resourceName, "revision", "2"),
+			},
+			{
+				Config: testAccResourceB2BucketConfig_basicPrivate(bucketName),
+				Check:  resource.TestCheckResourceAttr(resourceName, "revision", "3"),
+			},
+		},
+	})
+}
+
+func testAccResourceB2BucketConfig_basicPrivate(bucketName string) string {
+	return fmt.Sprintf(`
+resource "b2_bucket" "test" {
+  bucket_name = "%s"
+  bucket_type = "allPrivate"
+}
+`, bucketName)
 }
 
 func testAccResourceB2BucketConfig_basic(bucketName string) string {


### PR DESCRIPTION
Fixes #102.

- `revision` is a computed-only attribute, so Terraform froze its prior value during an update and reported the new value as drift on the next plan (`~ revision = 2 -> 3`).
- Add a `CustomizeDiff` that marks `revision` as computed whenever another field changes, so Terraform stores the value returned after apply instead of treating it as drift.
- Add `revision` assertions to the bucket acceptance tests and a dedicated `TestAccResourceB2Bucket_revisionUpdatedOnChange` covering create -> update.
- Ignore `tmp/` scratch dir.