### PR TITLE
Compare b2_bucket bucket_info keys case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Ignore `bucket_info` key case differences in `b2_bucket` resource, which caused a permanent diff
+
 ## [0.13.2] - 2026-07-27
 
 ### Infrastructure

--- a/b2/data_source_b2_bucket.go
+++ b/b2/data_source_b2_bucket.go
@@ -42,8 +42,9 @@ func dataSourceB2Bucket() *schema.Resource {
 				Computed:    true,
 			},
 			"bucket_info": {
-				Description: "User-defined information to be stored with the bucket.",
-				Type:        schema.TypeMap,
+				Description: "User-defined information stored with the bucket. Keys are returned in lower case, " +
+					"as B2 converts them when they are stored.",
+				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/b2/resource_b2_bucket.go
+++ b/b2/resource_b2_bucket.go
@@ -54,12 +54,16 @@ func resourceB2Bucket() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			"bucket_info": {
-				Description: "User-defined information to be stored with the bucket.",
-				Type:        schema.TypeMap,
+				Description: "User-defined information to be stored with the bucket. B2 converts keys to lower case, " +
+					"so they are stored and returned in lower case. Each key can be up to 50 bytes long, keys starting " +
+					"with 'b2-' are reserved, and all values together can take up to 10000 bytes.",
+				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional: true,
+				Optional:         true,
+				ValidateDiagFunc: validateLowerCaseMapKeys,
+				DiffSuppressFunc: suppressMapKeyCaseDiff("bucket_info"),
 			},
 			"cors_rules": {
 				Description: "The initial list of CORS rules for this bucket.",

--- a/b2/resource_b2_bucket_test.go
+++ b/b2/resource_b2_bucket_test.go
@@ -286,6 +286,48 @@ func TestAccResourceB2Bucket_revisionUpdatedOnChange(t *testing.T) {
 	})
 }
 
+func TestAccResourceB2Bucket_bucketInfoKeyCase(t *testing.T) {
+	resourceName := "b2_bucket.test"
+	bucketName := acctest.RandomWithPrefix("test-b2-tfp")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				// B2 stores the key in lower case, which must not show up as a permanent diff
+				Config: testAccResourceB2BucketConfig_bucketInfo(bucketName, "ManagedBy"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bucket_info.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "bucket_info.managedby", "Terraform"),
+				),
+			},
+			{
+				// The key stored in lower case must not be planned as a change back to the config one
+				Config:   testAccResourceB2BucketConfig_bucketInfo(bucketName, "ManagedBy"),
+				PlanOnly: true,
+			},
+			{
+				// Changing the key case only is not a change for B2
+				Config:   testAccResourceB2BucketConfig_bucketInfo(bucketName, "managedby"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccResourceB2BucketConfig_bucketInfo(bucketName string, key string) string {
+	return fmt.Sprintf(`
+resource "b2_bucket" "test" {
+  bucket_name = "%s"
+  bucket_type = "allPublic"
+  bucket_info = {
+    %s = "Terraform"
+  }
+}
+`, bucketName, key)
+}
+
 func testAccResourceB2BucketConfig_basicPrivate(bucketName string) string {
 	return fmt.Sprintf(`
 resource "b2_bucket" "test" {

--- a/b2/utils.go
+++ b/b2/utils.go
@@ -10,9 +10,93 @@
 
 package b2
 
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
 func If[T any](cond bool, vtrue, vfalse T) T {
 	if cond {
 		return vtrue
 	}
 	return vfalse
+}
+
+// suppressMapKeyCaseDiff suppresses diffs of a map attribute caused only by B2 storing keys in lower case.
+func suppressMapKeyCaseDiff(attribute string) schema.SchemaDiffSuppressFunc {
+	prefix := attribute + "."
+
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		key, found := strings.CutPrefix(k, prefix)
+		if !found || key == "%" {
+			return false
+		}
+
+		config, ok := configMapAttribute(d, attribute)
+		if !ok {
+			return false
+		}
+		state, _ := d.GetChange(attribute)
+
+		key = strings.ToLower(key)
+		stateValue, inState := lookupLowerCaseKey(stateMapAttribute(state), key)
+		configValue, inConfig := lookupLowerCaseKey(config, key)
+
+		return inState && inConfig && stateValue == configValue
+	}
+}
+
+// configMapAttribute reads a map attribute from the raw config, so that values missing from the
+// config are not read from the state instead. It reports false when the value cannot be compared.
+func configMapAttribute(d *schema.ResourceData, attribute string) (map[string]string, bool) {
+	config := d.GetRawConfig()
+	if config.IsNull() || !config.Type().IsObjectType() || !config.Type().HasAttribute(attribute) {
+		return nil, false
+	}
+
+	value := config.GetAttr(attribute)
+	if !value.IsKnown() {
+		return nil, false
+	}
+	if value.IsNull() {
+		return map[string]string{}, true
+	}
+
+	result := make(map[string]string, value.LengthInt())
+	for it := value.ElementIterator(); it.Next(); {
+		elemKey, elemValue := it.Element()
+		if elemValue.IsNull() || !elemValue.IsKnown() {
+			return nil, false
+		}
+		result[elemKey.AsString()] = elemValue.AsString()
+	}
+
+	return result, true
+}
+
+// stateMapAttribute converts a map attribute read from the state. Values that are not strings
+// are dropped, which makes their key look absent and leaves its diff in place.
+func stateMapAttribute(state interface{}) map[string]string {
+	m, _ := state.(map[string]interface{})
+
+	result := make(map[string]string, len(m))
+	for key, value := range m {
+		if s, ok := value.(string); ok {
+			result[key] = s
+		}
+	}
+
+	return result
+}
+
+// lookupLowerCaseKey returns the value stored under the key whose lower case form is the given one.
+func lookupLowerCaseKey(m map[string]string, lowerCaseKey string) (string, bool) {
+	for key, value := range m {
+		if strings.ToLower(key) == lowerCaseKey {
+			return value, true
+		}
+	}
+
+	return "", false
 }

--- a/b2/validators.go
+++ b/b2/validators.go
@@ -13,6 +13,11 @@ package b2
 import (
 	"encoding/base64"
 	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -54,4 +59,34 @@ func StringLenExact(length int) schema.SchemaValidateFunc {
 
 		return warnings, errors
 	}
+}
+
+// validateLowerCaseMapKeys warns about map keys that B2 stores in lower case.
+func validateLowerCaseMapKeys(i interface{}, path cty.Path) diag.Diagnostics {
+	// Values that are not maps are already rejected by the SDK before this runs
+	m, ok := i.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		if key != strings.ToLower(key) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	diags := make(diag.Diagnostics, 0, len(keys))
+	for _, key := range keys {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "Key will be stored in lower case",
+			Detail: fmt.Sprintf("B2 converts keys to lower case, so %q will be stored and returned as %q.",
+				key, strings.ToLower(key)),
+			AttributePath: path.Copy().IndexString(key),
+		})
+	}
+
+	return diags
 }

--- a/docs/data-sources/bucket.md
+++ b/docs/data-sources/bucket.md
@@ -23,7 +23,7 @@ B2 bucket data source.
 
 - `account_id` (String) Account ID that the bucket belongs to.
 - `bucket_id` (String) The ID of the bucket.
-- `bucket_info` (Map of String) User-defined information to be stored with the bucket.
+- `bucket_info` (Map of String) User-defined information stored with the bucket. Keys are returned in lower case, as B2 converts them when they are stored.
 - `bucket_type` (String) The bucket type. Either 'allPublic', meaning that files in this bucket can be downloaded by anybody, or 'allPrivate'.
 - `cors_rules` (List of Object) The initial list of CORS rules for this bucket. (see [below for nested schema](#nestedatt--cors_rules))
 - `default_server_side_encryption` (List of Object) The default server-side encryption settings of this bucket. (see [below for nested schema](#nestedatt--default_server_side_encryption))

--- a/docs/resources/bucket.md
+++ b/docs/resources/bucket.md
@@ -22,7 +22,7 @@ B2 bucket resource.
 
 ### Optional
 
-- `bucket_info` (Map of String) User-defined information to be stored with the bucket.
+- `bucket_info` (Map of String) User-defined information to be stored with the bucket. B2 converts keys to lower case, so they are stored and returned in lower case. Each key can be up to 50 bytes long, keys starting with 'b2-' are reserved, and all values together can take up to 10000 bytes.
 - `cors_rules` (Block List) The initial list of CORS rules for this bucket. (see [below for nested schema](#nestedblock--cors_rules))
 - `default_server_side_encryption` (Block List, Max: 1) The default server-side encryption settings for this bucket. (see [below for nested schema](#nestedblock--default_server_side_encryption))
 - `file_lock_configuration` (Block List) File lock enabled flag, and default retention settings. (see [below for nested schema](#nestedblock--file_lock_configuration))

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,10 @@ toolchain go1.25.11
 
 require github.com/hashicorp/terraform-plugin-log v0.9.0
 
-require github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
+require (
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
+)
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
@@ -19,7 +22,6 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.2 // indirect


### PR DESCRIPTION
Fixes #150.

- Compare `bucket_info` keys case-insensitively in `b2_bucket`, so a config key with uppercase characters no longer conflicts with the lower case key B2 stores and returns. Before this change every plan proposed the same no-op update, forever.
- Warn at plan time when a `bucket_info` key contains uppercase characters, naming the lower case form it will be stored as, so the conversion is visible rather than silent.
- Document the bucket info key rules on the `b2_bucket` resource and the lower case keys on the `b2_bucket` data source.

State keeps the keys as B2 returns them - lower case - so `bucket_info` lookups on the resource have to use the lower case key.

Verified against B2 with the `b2` CLI: `--bucket-info '{"ManagedBy":"Terraform"}'` is stored and returned as `{"managedby": "Terraform"}`. Colliding keys (`Foo` and `foo`) are rejected by the API with `duplicate bucket info name: foo (bad_request)`, so the provider leaves that case to the server instead of duplicating the rule.

New acceptance test `TestAccResourceB2Bucket_bucketInfoKeyCase` fails without the fix with `Plan: 0 to add, 1 to change, 0 to destroy` and passes with it.
