### PR TITLE
Stop file_info diffs forcing b2_bucket_file_version re-upload on every apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Ignore `bucket_info` key case differences in `b2_bucket` resource, which caused a permanent diff
+* Ignore `file_info` key case differences in `b2_bucket_file_version` resource, which caused the file to be re-uploaded on every apply
+* Stop re-uploading `b2_bucket_file_version` files whose `file_info` gained a key from B2, such as `sse_c_key_id` or `large_file_sha1`
+* Warn when `file_info` in `b2_bucket_file_version` resource sets a key that B2 sets itself, such as `sse_c_key_id` or `large_file_sha1`
 
 ## [0.13.2] - 2026-07-27
 

--- a/b2/resource_b2_bucket.go
+++ b/b2/resource_b2_bucket.go
@@ -62,7 +62,7 @@ func resourceB2Bucket() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Optional:         true,
-				ValidateDiagFunc: validateLowerCaseMapKeys,
+				ValidateDiagFunc: validateMapKeys(),
 				DiffSuppressFunc: suppressMapKeyCaseDiff("bucket_info"),
 			},
 			"cors_rules": {

--- a/b2/resource_b2_bucket_file_version.go
+++ b/b2/resource_b2_bucket_file_version.go
@@ -18,6 +18,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+// serverAddedFileInfoKeys are the file info keys that B2 adds on upload, so they are in the state
+// without ever being in the config.
+var serverAddedFileInfoKeys = []string{"sse_c_key_id", "large_file_sha1"}
+
 func resourceB2BucketFileVersion() *schema.Resource {
 	return &schema.Resource{
 		Description: "B2 bucket file version resource.",
@@ -58,17 +62,18 @@ func resourceB2BucketFileVersion() *schema.Resource {
 				},
 			},
 			"file_info": {
-				Description: "The custom information that is uploaded with the file.",
-				Type:        schema.TypeMap,
+				Description: "The custom information that is uploaded with the file. B2 converts keys to lower " +
+					"case, so they are stored and returned in lower case. B2 also adds 'sse_c_key_id' to files " +
+					"uploaded in SSE-C mode, and 'large_file_sha1' to large files.",
+				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return k == "file_info.sse_c_key_id" || old == new
-				},
+				Optional:         true,
+				ForceNew:         true,
+				Computed:         true,
+				ValidateDiagFunc: validateMapKeys(serverAddedFileInfoKeys...),
+				DiffSuppressFunc: suppressMapKeyCaseDiff("file_info", serverAddedFileInfoKeys...),
 			},
 			"server_side_encryption": {
 				Description: "Server-side encryption settings.",

--- a/b2/resource_b2_bucket_file_version_test.go
+++ b/b2/resource_b2_bucket_file_version_test.go
@@ -196,6 +196,65 @@ func TestAccResourceB2BucketFileVersion_sse_c(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "upload_timestamp", regexp.MustCompile("^[0-9]{13}$")),
 				),
 			},
+			{
+				// The sse_c_key_id added by B2 must not be planned as a removal of a file info key
+				Config:   testAccResourceB2BucketFileVersionConfig_sse_c(bucketName, tempFile),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceB2BucketFileVersion_fileInfoKeyCase(t *testing.T) {
+	resourceName := "b2_bucket_file_version.test"
+
+	bucketName := acctest.RandomWithPrefix("test-b2-tfp")
+	tempFile := createTempFileString(t, "hello")
+	defer func() { _ = os.Remove(tempFile) }()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				// B2 stores the key in lower case, which must not show up as a permanent diff
+				Config: testAccResourceB2BucketFileVersionConfig_fileInfo(bucketName, tempFile,
+					`ManagedBy = "Terraform"`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "file_info.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "file_info.managedby", "Terraform"),
+				),
+			},
+			{
+				// The key stored in lower case must not be planned as a new file version
+				Config: testAccResourceB2BucketFileVersionConfig_fileInfo(bucketName, tempFile,
+					`ManagedBy = "Terraform"`),
+				PlanOnly: true,
+			},
+			{
+				// Changing the key case only is not a change for B2
+				Config: testAccResourceB2BucketFileVersionConfig_fileInfo(bucketName, tempFile,
+					`managedby = "Terraform"`),
+				PlanOnly: true,
+			},
+			{
+				// Adding a key requires a new file version, as B2 stores file info on upload only
+				Config: testAccResourceB2BucketFileVersionConfig_fileInfo(bucketName, tempFile,
+					`ManagedBy = "Terraform"
+    description = "the file"`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "file_info.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "file_info.managedby", "Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "file_info.description", "the file"),
+				),
+			},
+			{
+				// Removing a key requires a new file version too, so it must not be suppressed
+				Config: testAccResourceB2BucketFileVersionConfig_fileInfo(bucketName, tempFile,
+					`ManagedBy = "Terraform"`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }
@@ -213,6 +272,24 @@ resource "b2_bucket_file_version" "test" {
   source = "%s"
 }
 `, bucketName, tempFile)
+}
+
+func testAccResourceB2BucketFileVersionConfig_fileInfo(bucketName string, tempFile string, fileInfo string) string {
+	return fmt.Sprintf(`
+resource "b2_bucket" "test" {
+  bucket_name = "%s"
+  bucket_type = "allPublic"
+}
+
+resource "b2_bucket_file_version" "test" {
+  bucket_id = b2_bucket.test.id
+  file_name = "temp.txt"
+  source = "%s"
+  file_info = {
+    %s
+  }
+}
+`, bucketName, tempFile, fileInfo)
 }
 
 func testAccResourceB2BucketFileVersionConfig_all(bucketName string, tempFile string) string {

--- a/b2/templates.go
+++ b/b2/templates.go
@@ -44,8 +44,9 @@ func getDataSourceFileVersionsElem() *schema.Resource {
 				Computed:    true,
 			},
 			"file_info": {
-				Description: "The custom information that is uploaded with the file.",
-				Type:        schema.TypeMap,
+				Description: "The custom information that is uploaded with the file. Keys are returned in lower " +
+					"case, as B2 converts them when they are stored.",
+				Type: schema.TypeMap,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/b2/utils.go
+++ b/b2/utils.go
@@ -23,13 +23,21 @@ func If[T any](cond bool, vtrue, vfalse T) T {
 	return vfalse
 }
 
-// suppressMapKeyCaseDiff suppresses diffs of a map attribute caused only by B2 storing keys in lower case.
-func suppressMapKeyCaseDiff(attribute string) schema.SchemaDiffSuppressFunc {
+// suppressMapKeyCaseDiff suppresses diffs of a map attribute caused only by B2 storing keys in lower
+// case. Keys listed in serverAddedKeys are the ones B2 adds on its own, so finding them in the state
+// but not in the config is not a change. Attributes without such keys must not pass any, as then every
+// key missing from the config has been removed from it.
+func suppressMapKeyCaseDiff(attribute string, serverAddedKeys ...string) schema.SchemaDiffSuppressFunc {
 	prefix := attribute + "."
+
+	serverAdded := make(map[string]struct{}, len(serverAddedKeys))
+	for _, key := range serverAddedKeys {
+		serverAdded[strings.ToLower(key)] = struct{}{}
+	}
 
 	return func(k, old, new string, d *schema.ResourceData) bool {
 		key, found := strings.CutPrefix(k, prefix)
-		if !found || key == "%" {
+		if !found {
 			return false
 		}
 
@@ -38,13 +46,48 @@ func suppressMapKeyCaseDiff(attribute string) schema.SchemaDiffSuppressFunc {
 			return false
 		}
 		state, _ := d.GetChange(attribute)
+		stateMap := stateMapAttribute(state)
+
+		// The element count diff carries key removals that the element diffs do not, so it can only be
+		// suppressed once the whole map is known to hold what the config asks for
+		if key == "%" {
+			return len(serverAdded) > 0 && mapStoresConfig(config, stateMap, serverAdded)
+		}
 
 		key = strings.ToLower(key)
-		stateValue, inState := lookupLowerCaseKey(stateMapAttribute(state), key)
 		configValue, inConfig := lookupLowerCaseKey(config, key)
+		if !inConfig {
+			_, isServerAdded := serverAdded[key]
+			return isServerAdded
+		}
 
-		return inState && inConfig && stateValue == configValue
+		stateValue, inState := lookupLowerCaseKey(stateMap, key)
+
+		return inState && stateValue == configValue
 	}
+}
+
+// mapStoresConfig reports whether every configured key is stored with the same value, and whether
+// every stored key is either configured or one that B2 adds on its own.
+func mapStoresConfig(config, state map[string]string, serverAdded map[string]struct{}) bool {
+	for key, configValue := range config {
+		stateValue, inState := lookupLowerCaseKey(state, strings.ToLower(key))
+		if !inState || stateValue != configValue {
+			return false
+		}
+	}
+
+	for key := range state {
+		key = strings.ToLower(key)
+		if _, inConfig := lookupLowerCaseKey(config, key); inConfig {
+			continue
+		}
+		if _, isServerAdded := serverAdded[key]; !isServerAdded {
+			return false
+		}
+	}
+
+	return true
 }
 
 // configMapAttribute reads a map attribute from the raw config, so that values missing from the

--- a/b2/validators.go
+++ b/b2/validators.go
@@ -61,32 +61,53 @@ func StringLenExact(length int) schema.SchemaValidateFunc {
 	}
 }
 
-// validateLowerCaseMapKeys warns about map keys that B2 stores in lower case.
-func validateLowerCaseMapKeys(i interface{}, path cty.Path) diag.Diagnostics {
-	// Values that are not maps are already rejected by the SDK before this runs
-	m, ok := i.(map[string]interface{})
-	if !ok {
-		return nil
+// validateMapKeys warns about map keys that B2 stores in lower case, and about keys listed in
+// serverAddedKeys, which B2 sets on its own.
+func validateMapKeys(serverAddedKeys ...string) schema.SchemaValidateDiagFunc {
+	serverAdded := make(map[string]struct{}, len(serverAddedKeys))
+	for _, key := range serverAddedKeys {
+		serverAdded[strings.ToLower(key)] = struct{}{}
 	}
 
-	keys := make([]string, 0, len(m))
-	for key := range m {
-		if key != strings.ToLower(key) {
+	return func(i interface{}, path cty.Path) diag.Diagnostics {
+		// Values that are not maps are already rejected by the SDK before this runs
+		m, ok := i.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		keys := make([]string, 0, len(m))
+		for key := range m {
 			keys = append(keys, key)
 		}
-	}
-	sort.Strings(keys)
+		sort.Strings(keys)
 
-	diags := make(diag.Diagnostics, 0, len(keys))
-	for _, key := range keys {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "Key will be stored in lower case",
-			Detail: fmt.Sprintf("B2 converts keys to lower case, so %q will be stored and returned as %q.",
-				key, strings.ToLower(key)),
-			AttributePath: path.Copy().IndexString(key),
-		})
-	}
+		diags := make(diag.Diagnostics, 0, len(keys))
+		for _, key := range keys {
+			lowerCaseKey := strings.ToLower(key)
 
-	return diags
+			if key != lowerCaseKey {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Key will be stored in lower case",
+					Detail: fmt.Sprintf("B2 converts keys to lower case, so %q will be stored and returned as %q.",
+						key, lowerCaseKey),
+					AttributePath: path.Copy().IndexString(key),
+				})
+			}
+
+			if _, isServerAdded := serverAdded[lowerCaseKey]; isServerAdded {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Key is set by B2",
+					Detail: fmt.Sprintf("B2 sets %q on its own, so the configured value can be replaced on "+
+						"upload, and removing the key from the configuration later is not detected as a change.",
+						lowerCaseKey),
+					AttributePath: path.Copy().IndexString(key),
+				})
+			}
+		}
+
+		return diags
+	}
 }

--- a/docs/resources/bucket_file_version.md
+++ b/docs/resources/bucket_file_version.md
@@ -24,7 +24,7 @@ B2 bucket file version resource.
 ### Optional
 
 - `content_type` (String) Content type. If not set, it will be set based on the file extension. **Modifying this attribute will force creation of a new resource.**
-- `file_info` (Map of String) The custom information that is uploaded with the file. **Modifying this attribute will force creation of a new resource.**
+- `file_info` (Map of String) The custom information that is uploaded with the file. B2 converts keys to lower case, so they are stored and returned in lower case. B2 also adds 'sse_c_key_id' to files uploaded in SSE-C mode, and 'large_file_sha1' to large files. **Modifying this attribute will force creation of a new resource.**
 - `server_side_encryption` (Block List, Max: 1) Server-side encryption settings. **Modifying this attribute will force creation of a new resource.** (see [below for nested schema](#nestedblock--server_side_encryption))
 
 ### Read-Only


### PR DESCRIPTION
Fixes #152.

* Compare `file_info` keys case-insensitively in `b2_bucket_file_version`, so an uppercase key such as `ManagedBy` no longer forces a replacement - and a re-upload of the object - on every apply. The attribute is `ForceNew`, so this was worse than the `bucket_info` case in #150.
* Stop `file_info` forcing a replacement when B2 adds a key of its own. `sse_c_key_id` (SSE-C) and `large_file_sha1` (large files) change the element count, and `file_info.%` inherits `ForceNew`, so an SSE-C upload with an explicit `file_info` re-uploaded the object on every apply. Separate pre-existing bug, found while fixing the one above - the existing `_sse_c` test had a single step and no `PlanOnly`, so nothing caught it.
* Warn when `file_info` sets a key that B2 sets itself. Verified with the `b2` CLI that B2 accepts both `large_file_sha1` and `sse_c_key_id` from a client and stores them verbatim, so no layer below the provider reports this.
* Share the lower case key warning with `bucket_info` through `validateMapKeys`, and the diff suppression through `suppressMapKeyCaseDiff`. `bucket_info` behaviour is unchanged - it passes no server-added keys, which keeps the old `file_info.%` early return.

Removing a key from `file_info` still forces a new file version, since B2 stores file info on upload only.

Two corrections to the issue text:

* `src_last_modified_millis` is not on this path. b2sdk writes it only in the sync engine, never in `upload_local_file`, so the provider never sees it. The `Computed` flag matters for `sse_c_key_id` and `large_file_sha1` instead.
* No collision error. Keys that collide once lowercased are dropped silently by b2sdk before the request is sent, and `b2_upload_file` accepts duplicates without complaint. That belongs upstream in b2sdk and the service, not here.

Known limitation: a configuration that sets `sse_c_key_id` or `large_file_sha1` by hand and later removes it will not have the removal detected. The provider cannot tell a key B2 added from one the user deleted, as Terraform passes only the prior state, never the prior config. The new warning says so at the point the key is set.

Acceptance tests pass against B2, including the new `TestAccResourceB2BucketFileVersion_fileInfoKeyCase` and the `PlanOnly` step added to `TestAccResourceB2BucketFileVersion_sse_c`, which fails on `master`.
