### PR TITLE
Store b2_bucket lifecycle rules in config order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,19 @@ jobs:
         uses: zattoo/changelog@v2
         with:
           token: ${{ github.token }}
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Go ${{ env.GO_DEFAULT_VERSION }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_DEFAULT_VERSION }}
+      - name: Run unit tests
+        run: make test
   build:
-    needs: lint
+    needs: [lint, test]
     runs-on: ${{ matrix.conf.runner }}
     timeout-minutes: 60
     strategy:
@@ -96,7 +107,7 @@ jobs:
           path: python-bindings/dist/py-terraform-provider-b2
           if-no-files-found: error
           retention-days: 1
-  test:
+  testacc:
     needs: build
     env:
       B2_TEST_APPLICATION_KEY: ${{ secrets.B2_TEST_APPLICATION_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ignore `file_info` key case differences in `b2_bucket_file_version` resource, which caused the file to be re-uploaded on every apply
 * Stop re-uploading `b2_bucket_file_version` files whose `file_info` gained a key from B2, such as `sse_c_key_id` or `large_file_sha1`
 * Warn when `file_info` in `b2_bucket_file_version` resource sets a key that B2 sets itself, such as `sse_c_key_id` or `large_file_sha1`
+* Stop `b2_bucket` `lifecycle_rules` order diffs caused by B2 not guaranteeing the rule order (a permanent plan and needless `revision` bumps on every apply)
+
+### Infrastructure
+* Add `make test` target running unit tests and run them in CI
 
 ## [0.13.2] - 2026-07-27
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ vulncheck:
 
 test:
 	@test -f b2/py-terraform-provider-b2 || touch b2/py-terraform-provider-b2 # required by go:embed in bindings.go
-	@go test ./...
+	@go test ./... -v -count 1 -skip '^TestAcc' $(TESTARGS)
 
 testacc: _pybindings
 	@cp python-bindings/dist/py-terraform-provider-b2 b2/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 
 default: build
 
-.PHONY: _pybindings deps deps-check format lint vulncheck testacc clean build install docs docs-lint
+.PHONY: _pybindings deps deps-check format lint vulncheck test testacc clean build install docs docs-lint
 
 _pybindings:
 ifeq ($(origin NOPYBINDINGS), undefined)
@@ -45,6 +45,10 @@ lint: _pybindings
 vulncheck:
 	@test -f b2/py-terraform-provider-b2 || touch b2/py-terraform-provider-b2 # required by go:embed in bindings.go
 	@govulncheck ./...
+
+test:
+	@test -f b2/py-terraform-provider-b2 || touch b2/py-terraform-provider-b2 # required by go:embed in bindings.go
+	@go test ./...
 
 testacc: _pybindings
 	@cp python-bindings/dist/py-terraform-provider-b2 b2/

--- a/b2/resource_b2_bucket.go
+++ b/b2/resource_b2_bucket.go
@@ -152,6 +152,9 @@ func resourceB2BucketCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId(output.BucketId)
 
+	// B2 does not guarantee the order of lifecycle rules, store them in config order
+	output.LifecycleRules = orderLifecycleRules(output.LifecycleRules, d.Get("lifecycle_rules").([]interface{}))
+
 	err = client.Populate(ctx, OpResourceCreate, &output, d)
 	if err != nil {
 		return diag.FromErr(err)
@@ -182,6 +185,9 @@ func resourceB2BucketRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return nil
 	}
 
+	// B2 does not guarantee the order of lifecycle rules, store them in state order
+	output.LifecycleRules = orderLifecycleRules(output.LifecycleRules, d.Get("lifecycle_rules").([]interface{}))
+
 	err = client.Populate(ctx, OpResourceRead, &output, d)
 	if err != nil {
 		return diag.FromErr(err)
@@ -209,6 +215,9 @@ func resourceB2BucketUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// B2 does not guarantee the order of lifecycle rules, store them in config order
+	output.LifecycleRules = orderLifecycleRules(output.LifecycleRules, d.Get("lifecycle_rules").([]interface{}))
 
 	err = client.Populate(ctx, OpResourceUpdate, &output, d)
 	if err != nil {

--- a/b2/resource_b2_bucket_test.go
+++ b/b2/resource_b2_bucket_test.go
@@ -316,6 +316,65 @@ func TestAccResourceB2Bucket_bucketInfoKeyCase(t *testing.T) {
 	})
 }
 
+func TestAccResourceB2Bucket_lifecycleRulesOrder(t *testing.T) {
+	resourceName := "b2_bucket.test"
+	bucketName := acctest.RandomWithPrefix("test-b2-tfp")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				// B2 does not return lifecycle rules in the order they were set,
+				// the state must be stored in the config order regardless
+				Config: testAccResourceB2BucketConfig_lifecycleRulesOrder(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.0.file_name_prefix", "uploads/"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.0.days_from_uploading_to_hiding", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.1.file_name_prefix", "files/"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.1.days_from_hiding_to_deleting", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.2.file_name_prefix", "thumbnails/"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.2.days_from_uploading_to_hiding", "2"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.3.file_name_prefix", "avatars/"),
+					resource.TestCheckResourceAttr(resourceName, "lifecycle_rules.3.days_from_hiding_to_deleting", "2"),
+				),
+			},
+			{
+				// The rule order must not be planned as a change
+				Config:   testAccResourceB2BucketConfig_lifecycleRulesOrder(bucketName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccResourceB2BucketConfig_lifecycleRulesOrder(bucketName string) string {
+	return fmt.Sprintf(`
+resource "b2_bucket" "test" {
+  bucket_name = "%s"
+  bucket_type = "allPublic"
+
+  lifecycle_rules {
+    file_name_prefix = "uploads/"
+    days_from_uploading_to_hiding = 1
+  }
+  lifecycle_rules {
+    file_name_prefix = "files/"
+    days_from_hiding_to_deleting = 1
+  }
+  lifecycle_rules {
+    file_name_prefix = "thumbnails/"
+    days_from_uploading_to_hiding = 2
+  }
+  lifecycle_rules {
+    file_name_prefix = "avatars/"
+    days_from_hiding_to_deleting = 2
+  }
+}
+`, bucketName)
+}
+
 func testAccResourceB2BucketConfig_bucketInfo(bucketName string, key string) string {
 	return fmt.Sprintf(`
 resource "b2_bucket" "test" {

--- a/b2/utils.go
+++ b/b2/utils.go
@@ -23,6 +23,45 @@ func If[T any](cond bool, vtrue, vfalse T) T {
 	return vfalse
 }
 
+// orderLifecycleRules reorders lifecycle rules returned by B2 to match the order of
+// rules in desired. B2 does not guarantee the order of lifecycle rules in bucket
+// responses, which would otherwise cause a permanent diff (and a needless bucket
+// revision bump on every apply) for list-typed lifecycle_rules. Rules are matched
+// by file name prefix; rules missing from desired (e.g. added out-of-band) keep
+// the API order at the end of the list.
+func orderLifecycleRules(rules []LifecycleRule, desired []interface{}) []LifecycleRule {
+	if len(rules) < 2 || len(desired) == 0 {
+		return rules
+	}
+
+	consumed := make([]bool, len(rules))
+	result := make([]LifecycleRule, 0, len(rules))
+
+	for _, d := range desired {
+		wanted, ok := d.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		prefix, _ := wanted["file_name_prefix"].(string)
+
+		for i, rule := range rules {
+			if !consumed[i] && rule.FileNamePrefix == prefix {
+				consumed[i] = true
+				result = append(result, rule)
+				break
+			}
+		}
+	}
+
+	for i, rule := range rules {
+		if !consumed[i] {
+			result = append(result, rule)
+		}
+	}
+
+	return result
+}
+
 // suppressMapKeyCaseDiff suppresses diffs of a map attribute caused only by B2 storing keys in lower
 // case. Keys listed in serverAddedKeys are the ones B2 adds on its own, so finding them in the state
 // but not in the config is not a change. Attributes without such keys must not pass any, as then every

--- a/b2/utils_test.go
+++ b/b2/utils_test.go
@@ -1,0 +1,158 @@
+//####################################################################
+//
+// File: b2/utils_test.go
+//
+// Copyright 2025 Backblaze Inc. All Rights Reserved.
+//
+// License https://www.backblaze.com/using_b2_code.html
+//
+//####################################################################
+
+package b2
+
+import (
+	"testing"
+)
+
+func TestOrderLifecycleRules(t *testing.T) {
+	cases := map[string]struct {
+		rules   []LifecycleRule
+		desired []interface{}
+		want    []string // expected order of file name prefixes
+	}{
+		"empty": {
+			rules:   nil,
+			desired: nil,
+			want:    []string{},
+		},
+		"single rule": {
+			rules:   []LifecycleRule{{FileNamePrefix: "a/"}},
+			desired: []interface{}{map[string]interface{}{"file_name_prefix": "a/"}},
+			want:    []string{"a/"},
+		},
+		"already ordered": {
+			rules: []LifecycleRule{
+				{FileNamePrefix: "a/"},
+				{FileNamePrefix: "b/"},
+				{FileNamePrefix: "c/"},
+			},
+			desired: []interface{}{
+				map[string]interface{}{"file_name_prefix": "a/"},
+				map[string]interface{}{"file_name_prefix": "b/"},
+				map[string]interface{}{"file_name_prefix": "c/"},
+			},
+			want: []string{"a/", "b/", "c/"},
+		},
+		"reordered by B2": {
+			// B2 returns rules in an arbitrary order; the desired order must win
+			rules: []LifecycleRule{
+				{FileNamePrefix: "avatars/"},
+				{FileNamePrefix: "thumbnails/"},
+				{FileNamePrefix: "uploads/"},
+				{FileNamePrefix: "files/"},
+			},
+			desired: []interface{}{
+				map[string]interface{}{"file_name_prefix": "uploads/"},
+				map[string]interface{}{"file_name_prefix": "files/"},
+				map[string]interface{}{"file_name_prefix": "thumbnails/"},
+				map[string]interface{}{"file_name_prefix": "avatars/"},
+			},
+			want: []string{"uploads/", "files/", "thumbnails/", "avatars/"},
+		},
+		"no desired rules": {
+			// e.g. empty state (import); API order is kept
+			rules: []LifecycleRule{
+				{FileNamePrefix: "b/"},
+				{FileNamePrefix: "a/"},
+			},
+			desired: nil,
+			want:    []string{"b/", "a/"},
+		},
+		"rule added out-of-band": {
+			// rules missing from desired keep API order at the end
+			rules: []LifecycleRule{
+				{FileNamePrefix: "a/"},
+				{FileNamePrefix: "new/"},
+				{FileNamePrefix: "b/"},
+			},
+			desired: []interface{}{
+				map[string]interface{}{"file_name_prefix": "b/"},
+				map[string]interface{}{"file_name_prefix": "a/"},
+			},
+			want: []string{"b/", "a/", "new/"},
+		},
+		"rule removed out-of-band": {
+			// desired rules missing from B2 are skipped
+			rules: []LifecycleRule{
+				{FileNamePrefix: "a/"},
+			},
+			desired: []interface{}{
+				map[string]interface{}{"file_name_prefix": "a/"},
+				map[string]interface{}{"file_name_prefix": "removed/"},
+			},
+			want: []string{"a/"},
+		},
+		"duplicate prefixes": {
+			rules: []LifecycleRule{
+				{FileNamePrefix: "a/", DaysFromHidingToDeleting: 2},
+				{FileNamePrefix: "a/", DaysFromHidingToDeleting: 1},
+			},
+			desired: []interface{}{
+				map[string]interface{}{"file_name_prefix": "a/"},
+				map[string]interface{}{"file_name_prefix": "a/"},
+			},
+			want: []string{"a/", "a/"},
+		},
+		"non-rule desired entry": {
+			rules: []LifecycleRule{
+				{FileNamePrefix: "a/"},
+				{FileNamePrefix: "b/"},
+			},
+			desired: []interface{}{
+				"not a rule",
+				map[string]interface{}{"file_name_prefix": "b/"},
+			},
+			want: []string{"b/", "a/"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := orderLifecycleRules(tc.rules, tc.desired)
+
+			prefixes := make([]string, len(got))
+			for i, rule := range got {
+				prefixes[i] = rule.FileNamePrefix
+			}
+
+			if len(prefixes) != len(tc.want) {
+				t.Fatalf("expected prefixes %v, got %v", tc.want, prefixes)
+			}
+			for i := range tc.want {
+				if prefixes[i] != tc.want[i] {
+					t.Fatalf("expected prefixes %v, got %v", tc.want, prefixes)
+				}
+			}
+		})
+	}
+}
+
+func TestOrderLifecycleRulesKeepsRuleFields(t *testing.T) {
+	rules := []LifecycleRule{
+		{FileNamePrefix: "avatars/", DaysFromHidingToDeleting: 1},
+		{FileNamePrefix: "uploads/", DaysFromUploadingToHiding: 1},
+	}
+	desired := []interface{}{
+		map[string]interface{}{"file_name_prefix": "uploads/", "days_from_uploading_to_hiding": 1},
+		map[string]interface{}{"file_name_prefix": "avatars/", "days_from_hiding_to_deleting": 1},
+	}
+
+	got := orderLifecycleRules(rules, desired)
+
+	if got[0].FileNamePrefix != "uploads/" || got[0].DaysFromUploadingToHiding != 1 || got[0].DaysFromHidingToDeleting != 0 {
+		t.Errorf("first rule does not match B2 data for 'uploads/': %+v", got[0])
+	}
+	if got[1].FileNamePrefix != "avatars/" || got[1].DaysFromHidingToDeleting != 1 || got[1].DaysFromUploadingToHiding != 0 {
+		t.Errorf("second rule does not match B2 data for 'avatars/': %+v", got[1])
+	}
+}


### PR DESCRIPTION
B2 does not guarantee the order of lifecycle rules in bucket responses. As `lifecycle_rules` is a list, any reordering by the API caused a permanent diff, with every apply calling `update_bucket` and bumping the `revision`, only for the response to come back reordered again.

* Reorder the rules returned by B2 to match the order in config (or state, on refresh) before storing them, matching rules by file name prefix
* Rules added out-of-band keep the API order at the end, so genuine drift still shows up
* Add a `make test` target running unit tests and a `test` CI job, so unit tests run even when acceptance test credentials (and the pybindings binary they require) are unavailable
* Rename the old acceptance test job to `testacc` to match the make target
* Unit tests for the reordering helper and for the resource-level `lifecycle_rules` handling

Fixes #139
